### PR TITLE
Hybrid solution documented in the charter

### DIFF
--- a/draft-charter.html
+++ b/draft-charter.html
@@ -49,6 +49,11 @@
         border: 1px solid black;
         padding:  0.5em;
       }
+
+      details {
+        background: oldlace;
+        padding: 0.5em;
+      }
       body {	 
           background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 150 100' width='100%' height='50%' opacity='.06'> <g transform='translate(73,45) rotate(-40)'> <rect fill='none' stroke='red' stroke-width='2' width='120' x='-60' y='3' height='20' rx='10' ry='10'/> <text x='0' y='20' font-family='sans-serif' font-size='14' fill='red' text-anchor='middle'>Early Draft</text> </g> </svg>");
           background-position: top center;	 
@@ -87,9 +92,10 @@
         <p class="join"><a href="https://www.w3.org/2004/01/pp-impl/#####/join">Join the Working Group.</a></p>
       </div>
 
-         <p style="padding: 0.5ex; border: 1px solid green"> This proposed charter is available
-      on <a href="https://github.com/w3c/rdf-dir-literal">GitHub</a>. Feel free to raise <a href="https://github.com/w3c/rdf-dir-literal/issues">issues</a></i>.
-          </p>
+         <aside class=comment>
+           This proposed charter is available on <a href="https://github.com/w3c/rdf-dir-literal">GitHub</a>. Feel free to raise <a href="https://github.com/w3c/rdf-dir-literal/issues">issues</a></i>.
+           The text contains specific community feedback requests to find a consensus on the final charter proposal to be voted on by the AC.
+         </aside>
 
       <section id="details">
         <table class="summary-table">
@@ -197,7 +203,8 @@
 
         <p>More detailed milestones and updated publication schedules are available on the <a href="https://www.w3.org/[groupname]/PubStatus">group publication status page</a>.</p>
 
-        <p>The list below uses “RDF 1.2”, “SPARQL 1.2”, and “RDFa 1.2”, etc, to designate the new releases; this should be considered as indicative only. It will be the decision of the Working Group to choose the final version numbers.</p>
+        <p>The list below uses “RDF 1.2” or “RDFa 1.2”, etc., to designate the new releases; this should be considered as indicative only. It will be the decision of the Working Group to choose the final version numbers.</p>
+
 
         <section id="normative">
           <h3>
@@ -206,88 +213,134 @@
           <p>
             The Working Group will deliver the following <em>updated</em> specifications referring to the new version of the <a href="https://www.w3.org/rdf11-concepts#section-Graph-Literal"><code>langString</code> datatype</a> (when applicable) and with possible editorial errata changed:
           </p>
-          <dl id="deliverable-list">
-            <dt id="rdf" class="spec">RDF 1.2</dt>
-            <dd>
-               This term refers to a family of documents, published in 2014. The current list comprises:
-               <ul>
-                 <li><a href="https://www.w3.org/TR/2014/REC-rdf11-concepts-20140225/">RDF 1.1 Concepts and Abstract Syntax</a></li>
-                 <li><a href="http://www.w3.org/TR/2014/REC-rdf11-mt-20140225/">RDF 1.1 Semantics</a></li>
-                 <li><a href="http://www.w3.org/TR/2014/REC-rdf-schema-20140225/">RDF Schema 1.1</a></li>
-                 <li><a href="http://www.w3.org/TR/2014/REC-turtle-20140225/">RDF 1.1 Turtle</a></li>
-                 <li><a href="http://www.w3.org/TR/2014/REC-trig-20140225/">RDF 1.1 TriG</a></li>
-                 <li><a href="http://www.w3.org/TR/2014/REC-n-triples-20140225/">RDF 1.1 N-Triples</a></li>
-                 <li><a href="http://www.w3.org/TR/2014/REC-n-quads-20140225/">RDF 1.1 N-Quads</a></li>
-                 <li><a href="http://www.w3.org/TR/2014/REC-rdf-syntax-grammar-20140225/">RDF 1.2 XML Syntax</a></li>
-               </ul>
-               <p>See also <a href="https://www.w3.org/2001/sw/wiki/RDF1.1_Errata">errata</a>.</p>
-            </dd>
-            
-            <dt id="rdfa" class="spec">RDFa 1.2</dt>
-            <dd>
-               This term refers to a family of documents, published in 2015. The current list comprises:
-               <ul>
-                 <li><a href="http://www.w3.org/TR/2015/REC-rdfa-core-20150317/">RDFa Core 1.1 - Third Edition</a></li>
-                 <li><a href="http://www.w3.org/TR/2015/REC-html-rdfa-20150317/">HTML+RDFa 1.1 - Second Edition</a></li>
-                 <li><a href="http://www.w3.org/TR/2015/REC-xhtml-rdfa-20150317/">XHTML+RDFa 1.1 - Third Edition</a></li>
-                 <li><a href="http://www.w3.org/TR/2015/REC-rdfa-lite-20150317/">RDFa Lite 1.1 - Second Edition</a></li>
-               </ul>
-               <p>See also <a href="https://www.w3.org/2001/sw/wiki/RDFa_1.1._Errata">errata</a>.</p>
-            </dd>
 
-            <dt id="sparql" class="spec">SPARQL 1.2</dt>
-            <dd>
-               This term refers to a family of documents, published in 2013. The current list comprises:
-               <ul>
-                <li><a href="http://www.w3.org/TR/2013/REC-sparql11-overview-20130321/">SPARQL 1.1 Overview</a></li>
-                <li><a href="http://www.w3.org/TR/2013/REC-sparql11-query-20130321/">SPARQL 1.1 Query Language</a></li>
-                <li><a href="http://www.w3.org/TR/2013/REC-sparql11-update-20130321/">SPARQL 1.1 Update</a></li>
-                <li><a href="http://www.w3.org/TR/2013/REC-sparql11-service-description-20130321/">SPARQL 1.1 Service Description</a></li>
-                <li><a href="http://www.w3.org/TR/2013/REC-sparql11-federated-query-20130321/">SPARQL 1.1 Federated Query</a></li>
-                <li><a href="https://www.w3.org/TR/2013/REC-sparql11-results-json-20130321/">SPARQL 1.1 Query Results JSON Format</a></li>
-                <li><a href="https://www.w3.org/TR/2013/REC-sparql11-results-csv-tsv-20130321/">SPARQL 1.1 Query Results CSV and TSV Formats</a></li>
-                <li><a href="http://www.w3.org/TR/2013/REC-rdf-sparql-XMLres-20130321/">SPARQL Query Results XML Format (Second Edition)</a></li>
-                <li><a href="http://www.w3.org/TR/2013/REC-sparql11-entailment-20130321/">SPARQL 1.1 Entailment Regimes</a></li>
-                <li><a href="http://www.w3.org/TR/2013/REC-sparql11-entailment-20130321/">SPARQL 1.1 Entailment Regimes</a></li>
-                <li><a href="http://www.w3.org/TR/2013/REC-sparql11-protocol-20130321/">SPARQL 1.1 Protocol</a></li>
-                <li><a href="http://www.w3.org/TR/2013/REC-sparql11-http-rdf-update-20130321/">SPARQL 1.1 Graph Store HTTP Protocol</a></li>
-              </ul>
-              <p>See also <a href="https://www.w3.org/2013/sparql-errata">errata</a>.</p>
-            </dd>
-            <dt id="shacl" class="spec">SHACL 1.1</dt>
-            <dd>
-                This term refers one document, published in 2017:
-                <ul>
-                  <li><a href="https://www.w3.org/TR/2017/REC-shacl-20170720/">Shapes Constraint Language (SHACL)</a></li>
-                </ul>
-                <p>See also <a href="https://github.com/w3c/data-shapes/issues">errata</a>.</p>
-              </dd>
+          <aside class=comment>
+              For this preliminary draft we are currently considering two different approaches for the deliverables: one that is based on an integral update of all specifications based on RDF but which would lead to significant deployment issues, while the other is based on a “hybrid” approach that would allow a staged deployment. These are described in more details in the sections on <a href="https://w3c.github.io/rdf-dir-literal/#extending-lang-string">extending <code>langString</code></a> and <a href="https://w3c.github.io/rdf-dir-literal/#hybrid">describing a hybrid approach</a> in the accompanying document. We are requesting a community feedback on which approach to follow in the final charter.
+          </aside>
+    
+          <details style="margin-top:2em">
+              <summary><span style="font-size: 120%; color: darkblue">Deliverables for the “Integral update” alternative</span></summary>
+              <dl id="deliverable-list">
+                  <dt id="rdf" class="spec">RDF 1.2</dt>
+                  <dd>
+                     This term refers to a family of documents, published in 2014. The current list comprises:
+                     <ul>
+                       <li><a href="https://www.w3.org/TR/2014/REC-rdf11-concepts-20140225/">RDF 1.1 Concepts and Abstract Syntax</a></li>
+                       <li><a href="http://www.w3.org/TR/2014/REC-rdf11-mt-20140225/">RDF 1.1 Semantics</a></li>
+                       <li><a href="http://www.w3.org/TR/2014/REC-rdf-schema-20140225/">RDF Schema 1.1</a></li>
+                       <li><a href="http://www.w3.org/TR/2014/REC-turtle-20140225/">RDF 1.1 Turtle</a></li>
+                       <li><a href="http://www.w3.org/TR/2014/REC-trig-20140225/">RDF 1.1 TriG</a></li>
+                       <li><a href="http://www.w3.org/TR/2014/REC-n-triples-20140225/">RDF 1.1 N-Triples</a></li>
+                       <li><a href="http://www.w3.org/TR/2014/REC-n-quads-20140225/">RDF 1.1 N-Quads</a></li>
+                       <li><a href="http://www.w3.org/TR/2014/REC-rdf-syntax-grammar-20140225/">RDF 1.2 XML Syntax</a></li>
+                     </ul>
+                     <p>See also <a href="https://www.w3.org/2001/sw/wiki/RDF1.1_Errata">errata</a>.</p>
+                  </dd>
+                  
+                  <dt id="rdfa" class="spec">RDFa 1.2</dt>
+                  <dd>
+                     This term refers to a family of documents, published in 2015. The current list comprises:
+                     <ul>
+                       <li><a href="http://www.w3.org/TR/2015/REC-rdfa-core-20150317/">RDFa Core 1.1 - Third Edition</a></li>
+                       <li><a href="http://www.w3.org/TR/2015/REC-html-rdfa-20150317/">HTML+RDFa 1.1 - Second Edition</a></li>
+                       <li><a href="http://www.w3.org/TR/2015/REC-xhtml-rdfa-20150317/">XHTML+RDFa 1.1 - Third Edition</a></li>
+                       <li><a href="http://www.w3.org/TR/2015/REC-rdfa-lite-20150317/">RDFa Lite 1.1 - Second Edition</a></li>
+                     </ul>
+                     <p>See also <a href="https://www.w3.org/2001/sw/wiki/RDFa_1.1._Errata">errata</a>.</p>
+                  </dd>
+      
+                  <dt id="sparql" class="spec">SPARQL 1.2</dt>
+                  <dd>
+                     This term refers to a family of documents, published in 2013. The current list comprises:
+                     <ul>
+                      <li><a href="http://www.w3.org/TR/2013/REC-sparql11-overview-20130321/">SPARQL 1.1 Overview</a></li>
+                      <li><a href="http://www.w3.org/TR/2013/REC-sparql11-query-20130321/">SPARQL 1.1 Query Language</a></li>
+                      <li><a href="http://www.w3.org/TR/2013/REC-sparql11-update-20130321/">SPARQL 1.1 Update</a></li>
+                      <li><a href="http://www.w3.org/TR/2013/REC-sparql11-service-description-20130321/">SPARQL 1.1 Service Description</a></li>
+                      <li><a href="http://www.w3.org/TR/2013/REC-sparql11-federated-query-20130321/">SPARQL 1.1 Federated Query</a></li>
+                      <li><a href="https://www.w3.org/TR/2013/REC-sparql11-results-json-20130321/">SPARQL 1.1 Query Results JSON Format</a></li>
+                      <li><a href="https://www.w3.org/TR/2013/REC-sparql11-results-csv-tsv-20130321/">SPARQL 1.1 Query Results CSV and TSV Formats</a></li>
+                      <li><a href="http://www.w3.org/TR/2013/REC-rdf-sparql-XMLres-20130321/">SPARQL Query Results XML Format (Second Edition)</a></li>
+                      <li><a href="http://www.w3.org/TR/2013/REC-sparql11-entailment-20130321/">SPARQL 1.1 Entailment Regimes</a></li>
+                      <li><a href="http://www.w3.org/TR/2013/REC-sparql11-entailment-20130321/">SPARQL 1.1 Entailment Regimes</a></li>
+                      <li><a href="http://www.w3.org/TR/2013/REC-sparql11-protocol-20130321/">SPARQL 1.1 Protocol</a></li>
+                      <li><a href="http://www.w3.org/TR/2013/REC-sparql11-http-rdf-update-20130321/">SPARQL 1.1 Graph Store HTTP Protocol</a></li>
+                    </ul>
+                    <p>See also <a href="https://www.w3.org/2013/sparql-errata">errata</a>.</p>
+                  </dd>
+                  <dt id="shacl" class="spec">SHACL 1.1</dt>
+                  <dd>
+                      This term refers one document, published in 2017:
+                      <ul>
+                        <li><a href="https://www.w3.org/TR/2017/REC-shacl-20170720/">Shapes Constraint Language (SHACL)</a></li>
+                      </ul>
+                      <p>See also <a href="https://github.com/w3c/data-shapes/issues">errata</a>.</p>
+                    </dd>
+      
+                  <dt id="csvw" class="spec">CSVW 1.1</dt>
+                  <dd>
+                  This term refers to a family of documents, published in 2015. The current list comprises:
+                    <ul>
+                      <li><a href="http://www.w3.org/TR/2015/REC-tabular-data-model-20151217/">Model for Tabular Data and Metadata on the Web</a></li>
+                      <li><a href="http://www.w3.org/TR/2015/REC-tabular-metadata-20151217/">Metadata Vocabulary for Tabular Data</a></li>
+                      <li><a href="http://www.w3.org/TR/2015/REC-csv2json-20151217/">Generating JSON from Tabular Data on the Web</a></li>
+                      <li><a href="http://www.w3.org/TR/2015/REC-csv2rdf-20151217/">Generating RDF from Tabular Data on the Web, </a></li>
+                    </ul>
+                    <p>See also <a href="https://www.w3.org/2013/csvw/errata/">errata</a>.</p>
+                  </dd>
+      
+                  <dt id="csvw" class="spec">RDB2RDF 1.1</dt>
+                  <dd>
+                  This term refers to a family of documents, published in 2015. The current list comprises:
+                    <ul>
+                      <li><a href="http://www.w3.org/TR/2012/REC-r2rml-20120927/">R2RML: RDB to RDF Mapping Language</a></li>
+                      <li><a href="http://www.w3.org/TR/2012/REC-rdb-direct-mapping-20120927/">A Direct Mapping of Relational Data to RDF</a></li>
+                    </ul>
+                    <p>See also <a href="https://www.w3.org/2001/sw/rdb2rdf/errata.html">errata</a>.</p>
+                  </dd>
+                </dl>
+          </details>
+  
 
-            <dt id="csvw" class="spec">CSVW 1.1</dt>
-            <dd>
-            This term refers to a family of documents, published in 2015. The current list comprises:
-              <ul>
-                <li><a href="http://www.w3.org/TR/2015/REC-tabular-data-model-20151217/">Model for Tabular Data and Metadata on the Web</a></li>
-                <li><a href="http://www.w3.org/TR/2015/REC-tabular-metadata-20151217/">Metadata Vocabulary for Tabular Data</a></li>
-                <li><a href="http://www.w3.org/TR/2015/REC-csv2json-20151217/">Generating JSON from Tabular Data on the Web</a></li>
-                <li><a href="http://www.w3.org/TR/2015/REC-csv2rdf-20151217/">Generating RDF from Tabular Data on the Web, </a></li>
-              </ul>
-              <p>See also <a href="https://www.w3.org/2013/csvw/errata/">errata</a>.</p>
-            </dd>
-
-            <dt id="csvw" class="spec">RDB2RDF 1.1</dt>
-            <dd>
-            This term refers to a family of documents, published in 2015. The current list comprises:
-              <ul>
-                <li><a href="http://www.w3.org/TR/2012/REC-r2rml-20120927/">R2RML: RDB to RDF Mapping Language</a></li>
-                <li><a href="http://www.w3.org/TR/2012/REC-rdb-direct-mapping-20120927/">A Direct Mapping of Relational Data to RDF</a></li>
-              </ul>
-              <p>See also <a href="https://www.w3.org/2001/sw/rdb2rdf/errata.html">errata</a>.</p>
-            </dd>
-          </dl>
+          <details style="margin-top:2em">
+              <summary><span style="font-size: 120%; color: darkblue">Deliverables for the “Hybrid” alternative</span></summary>
+              <dl id="deliverable-list">
+                <dt id="datatype" class="spec">RDF Datatype for Language Literals</dt>
+                <dd>
+                  <p>This specification defines one or more RDF datatypes to represent language literals with an optional base direction.</p>
+                </dd>
+                <dt id="rdf_bis" class="spec">RDF 1.2</dt>
+                <dd>
+                    This term refers to a family of documents, published in 2014. The current list comprises:
+                    <ul>
+                      <li><a href="https://www.w3.org/TR/2014/REC-rdf11-concepts-20140225/">RDF 1.1 Concepts and Abstract Syntax</a></li>
+                      <li><a href="http://www.w3.org/TR/2014/REC-rdf11-mt-20140225/">RDF 1.1 Semantics</a></li>
+                      <li><a href="http://www.w3.org/TR/2014/REC-rdf-schema-20140225/">RDF Schema 1.1</a></li>
+                      <li><a href="http://www.w3.org/TR/2014/REC-turtle-20140225/">RDF 1.1 Turtle</a></li>
+                      <li><a href="http://www.w3.org/TR/2014/REC-trig-20140225/">RDF 1.1 TriG</a></li>
+                      <li><a href="http://www.w3.org/TR/2014/REC-n-triples-20140225/">RDF 1.1 N-Triples</a></li>
+                      <li><a href="http://www.w3.org/TR/2014/REC-n-quads-20140225/">RDF 1.1 N-Quads</a></li>
+                      <li><a href="http://www.w3.org/TR/2014/REC-rdf-syntax-grammar-20140225/">RDF 1.2 XML Syntax</a></li>
+                    </ul>
+                    <p>See also <a href="https://www.w3.org/2001/sw/wiki/RDF1.1_Errata">errata</a>.</p>
+                </dd>
+                
+                <dt id="rdfa_bis" class="spec">RDFa 1.2</dt>
+                <dd>
+                    This term refers to a family of documents, published in 2015. The current list comprises:
+                    <ul>
+                      <li><a href="http://www.w3.org/TR/2015/REC-rdfa-core-20150317/">RDFa Core 1.1 - Third Edition</a></li>
+                      <li><a href="http://www.w3.org/TR/2015/REC-html-rdfa-20150317/">HTML+RDFa 1.1 - Second Edition</a></li>
+                      <li><a href="http://www.w3.org/TR/2015/REC-xhtml-rdfa-20150317/">XHTML+RDFa 1.1 - Third Edition</a></li>
+                      <li><a href="http://www.w3.org/TR/2015/REC-rdfa-lite-20150317/">RDFa Lite 1.1 - Second Edition</a></li>
+                    </ul>
+                    <p>See also <a href="https://www.w3.org/2001/sw/wiki/RDFa_1.1._Errata">errata</a>.</p>
+                </dd>
+              </dl>
+          </details>
 
           <p>
-            Note: most of these specifications may need no change (i.e., there are no editorial errata, and the addition of the base direction to a literal does not affect the technical content). They should nevertheless be republished to be in line, editorially, with the right version names and cross references, with the updated specifications.
+            Note: most of the current specifications may not need to change (i.e., there are no editorial errata, and the addition of the base direction to a literal does not affect the technical content). They should nevertheless be republished to be in line, editorially, with the right version names and cross references, with the updated specifications.
           </p>
         </section>
 
@@ -307,7 +360,7 @@
 
         <section id="timeline">
           <h3>Timeline</h3>
-            <p class="todo">Put here a timeline view of all deliverables.</p>
+
             <ul>
               <li>October 2019: First teleconference</li>
               <li>December 2019: FPWD for all the specifications listed <a href="#deliverable-list">above</a></li>
@@ -316,7 +369,7 @@
               <li>March 2021: Recommendations for all the specifications listed <a href="#deliverable-list">above</a></li>
             </ul>
 
-            <aside class="comment">See a possible <a href="https://github.com/w3c/rdf-dir-literal/issues/11">alternative timeline</a>, in view of the large list of documents, staging the deliverables.</aside>
+            <aside class="comment">See a possible <a href="https://github.com/w3c/rdf-dir-literal/issues/11">alternative timeline</a>, in view of the large list of documents, staging the deliverables. That alternative may not be relevant if the “hybrid” approach is adopted.</aside>
         </section>
       </section>
 

--- a/index.html
+++ b/index.html
@@ -90,11 +90,11 @@
         </p>
 
         <p>
-            This document collects some some of the possible solutions that came to the fore in various discussions. All these approaches have their pros and cons; the choice will have to be made by the community; the goal is to have a unified approach for all W3C specifications instead of each of those having to come up with some heuristics separately.
+            This document collects some of the possible solutions that came to the fore in various discussions. All these approaches have their pros and cons; the choice will have to be made by the community; the goal is to have a unified approach for all W3C specifications instead of each of those having to come up with some heuristics separately.
         </p>
 
         <p class=note>
-            The problem of setting the base direction for a string is, actually, the tip of the iceberg of internationalization issues around RDF literals. This document focuses on so far <em>only</em> only on establishing the overall directional context for a given string. The larger problems is the handling of directional and languages changes <em>within</em> a string. To solve that larger issue would require the use Unicode formatting characters in plain text strings or use HTML format strings, i.e., the <a data-cite="!rdf11-concepts#section-html"><code>HTML</code> datatype</a> of RDF 1.1&nbsp;[[rdf11-concepts]]. While both of these <em>can</em> be done in today’s RDF, there are several problems with both those approaches (see also [[string-meta]] for some of the issues) which warrants to find a somewhat simpler solution for the base direction case.
+            The problem of setting the base direction for a string is, actually, the tip of the iceberg of internationalization issues around RDF literals. This document focuses so far <em>only</em> on establishing the overall directional context for a given string. The larger problems is the handling of directional and languages changes <em>within</em> a string. To solve that larger issue would require the use of Unicode formatting characters in plain text strings, or the use of HTML format strings, i.e., the <a data-cite="!rdf11-concepts#section-html"><code>HTML</code> datatype</a> of RDF 1.1&nbsp;[[rdf11-concepts]]. While both of these <em>can</em> be done in today’s RDF, there are several problems with both those approaches (see also [[string-meta]] for some of the issues) which warrants to find a somewhat simpler solution for the base direction case.
         </p>
 
     </section>
@@ -115,7 +115,7 @@
             <section id='langString'>
                 <h2>The core definition</h2>
                 <p>
-                    The current definition for <code>langString</code> is in <a data-cite="!rdf11-concepts#section-Graph-Literal">section 3.3</a> of the RDF 1.1 document&nbsp;[[rdf11-concepts]]. It is based upon assigning a language tag, using&nbsp;[[bcp47]], to a string. It is somewhat of an odd case in the RDF&nbsp;1.1 model insofar as it has, in contrast to all other data types in RDF, an additional structure: the lexical space is a string <em>and</em> the additional (language) tag, and the value space of the datatype is also defined as a <em>tuple</em> consisting of the literal string and the language tag. This peculiarity means that <code>langString</code> literals have to be treated separately by all RDF implementations.
+                    The current definition for <code>langString</code> is in <a data-cite="!rdf11-concepts#section-Graph-Literal">section 3.3</a> of the RDF 1.1 document&nbsp;[[rdf11-concepts]]. It is based upon assigning a language tag, using&nbsp;[[bcp47]], to a string. It is somewhat of an odd case in the RDF&nbsp;1.1 model insofar as it has, in contrast to all other data types in RDF, an additional structure: the lexical form comprises a string <em>and</em> the additional (language) tag, and the value space of the datatype is also defined as a set of <em>tuples</em> consisting of the literal string and the language tag. This peculiarity means that <code>langString</code> literals have to be treated separately by all RDF implementations.
                 </p>
 
                 <p>
@@ -130,7 +130,7 @@
                 <h2>Serializations</h2>
 
                 <p>
-                    The serializations of a renewed <code>langString</code> SHOULD be defined in such way that the presence of a base direction tag is OPTIONAL. This is important to ensure that current RDF datasets would remain valid. This means the parsing of language literals should replace the missing base direction tag with <code>auto</code>.
+                    The serializations of a renewed <code>langString</code> SHOULD be defined in such way that the presence of a base direction tag is OPTIONAL. This is important to ensure that current RDF datasets would remain valid. This means that the parsing of language literals should replace the missing base direction tag with <code>auto</code>.
                 </p>
 
                 <section>
@@ -144,7 +144,7 @@
 							&lt;/rdf:Description>
 						</pre>
 
-                    <p>The presence of <code>rdf:dir</code> is optional and defaults to <code>auto</code>.</p>
+                    <p>The presence of <code>rdf:dir</code> is optional and it defaults to <code>auto</code>.</p>
                 </section>
 
                 <section>
@@ -156,13 +156,13 @@
 						</pre>
 
 
-                    <p>The presence of the <code>^…</code> tag is optional and defaults to <code>auto</code>.</p>
+                    <p>The presence of the <code>^…</code> tag is optional and it defaults to <code>auto</code>.</p>
                 </section>
 
                 <section>
                     <h2>JSON-LD</h2>
 
-                    <p>JSON-LD uses special JSON objects to express language literals that can be extended via the introduction of a new JSON-LD keywords <code>@direction</code>:</p>
+                    <p>JSON-LD uses special JSON objects (<em>value objects</em>) to express RDF literals, that can be extended via the introduction of a new JSON-LD keywords <code>@direction</code>:</p>
 
                     <pre class=nohighlight>
 							"ex:example" : {
@@ -172,7 +172,7 @@
 							}
 						</pre>
 
-                    <p>The presence of <code>@direction</code> is optional and defaults to <code>auto</code>.</p>
+                    <p>The presence of <code>@direction</code> is optional and it defaults to <code>auto</code>.</p>
                 </section>
             </section>
             <section>
@@ -183,7 +183,7 @@
                 </p>
 
                 <p id="full-family">
-                    A major problem with the approach is that, because it touches the “core” or RDF, such a change would affect a large number of recommendations that all rely on that core: SPARQL, SHACL, RDFa, R2RML, etc. That means that if the core RDF specification is updated, _all other documents_ may have to be updated at the same time, which becomes a significant endeavor. Similarly, deployment is also a major problem: Because language tagged literals are treated separately in RDF, all implementations (Jena, RDFLib, Sesame, various triple stores, Turtle and RDF/XML parsers and serializers, etc.) MUST be updated. That may take a long time, and it may not be easy to convince the community to do so.
+                    A major problem with the approach is that, because it touches the “core” or RDF, such a change would affect a large number of recommendations that all rely on that core: SPARQL, SHACL, RDFa, R2RML, etc. That means that if the core RDF specification is updated, <em>all other documents</em> may have to be updated at the same time, which becomes a significant endeavor. Similarly, deployment is also a major problem: Because language tagged literals are treated separately in RDF, all implementations (Jena, RDFLib, Sesame, various triple stores, Turtle and RDF/XML parsers and serializers, etc.) MUST be updated. That may take a long time, and it may not be easy to convince the community to do so.
                 </p>
             </section>
         </section>
@@ -197,7 +197,7 @@
             <section>
                 <h2>Core definition</h2>
                 <p>
-                    Defining a new datatype means is (per the <a data-cite="!rdf11-concepts#section-Datatypes">RDF specification</a>):
+                    Defining a new datatype means (per the <a data-cite="!rdf11-concepts#section-Datatypes">RDF specification</a>):
                 </p>
 
                 <ul>
@@ -242,7 +242,7 @@
                             <strong>XX</strong>: is a [[bcp47]] language tag
                         </li>
                         <li>
-                            <strong>YY</strong>: is <code>ltr</code> or <code>rtl</code>, with the semantics as defined for the <a data-cite=!html/dom.html#the-dir-attribute><code>dir</code> attribute</a> in&nbsp;[[html]]. This part may be missing.</dd>                    
+                            <strong>YY</strong>: is <code>ltr</code> or <code>rtl</code>, with the semantics as defined for the <a data-cite=!html/dom.html#the-dir-attribute><code>dir</code> attribute</a> in&nbsp;[[html]]. This part may be missing.                 
                         </li>
                      </ul>
 
@@ -314,7 +314,7 @@
                 </pre>
 
                 <p>
-                    could be considered as valid, generating a <code>LocalizableString</code>, or <code>i18n:*</code>, respectively, when mapped upon RDF. An advantage of introducing such a shorthand in JSON is that vanilla JSON may adopt the same pattern which can be used in general (see also the definition of <a data-cite="string-meta#Localizable-String-Dictionary"><code>Localizable</code></a>.)
+                    could be considered as valid, generating a <code>LocalizableString</code>, or <code>i18n:*</code>, respectively, when mapped upon RDF. An advantage of introducing such a shorthand in JSON is that vanilla JSON may adopt the same pattern which can be used in general (see also the definition of <a data-cite="string-meta#Localizable-String-Dictionary"><code>Localizable</code></a> in&nbsp;[[string-meta]].)
                 </p>
 
                 <p>
@@ -400,7 +400,7 @@
             <section>
                 <h2>Core definition</h2>
                 <p>
-                    Define the <code>-x-d-ltr</code> and <code>-x-d-rtl</code> private-use language subtags. I.e., ahe language tag could look like <code>lang-x-d-dir</code>, where <code>lang</code> is a valid [[bcp47]] language tag, and <code>dir</code>  MUST have the value of <code>ltr</code>, <code>rtl</code> with the semantics as defined for the <a data-cite=!html/dom.html#the-dir-attribute><code>dir</code> attribute</a> in&nbsp;[[html]]. Per definition this usage of this private-use tag is <em>restricted</em> to a specific family of specifications (at this moment one could restrict it to RDF, OWL, SPARQL, SKOS, etc., their various serializations, plus possibly JSON and CBOR).
+                    Define the <code>-x-d-ltr</code> and <code>-x-d-rtl</code> private-use language subtags. I.e., the language tag could look like <code>lang-x-d-dir</code>, where <code>lang</code> is a valid [[bcp47]] language tag, and <code>dir</code>  MUST have the value of <code>ltr</code>, <code>rtl</code> with the semantics as defined for the <a data-cite=!html/dom.html#the-dir-attribute><code>dir</code> attribute</a> in&nbsp;[[html]]. Per definition this usage of this private-use tag is <em>restricted</em> to a specific family of specifications (at this moment one could restrict it to RDF, OWL, SPARQL, SKOS, etc., their various serializations, plus possibly JSON and CBOR).
                 </p>
             </section>
 
@@ -431,7 +431,7 @@
                 <h2>Pros and Cons</h2>
 
                 <p>
-                    A major advantage of this approach are similar to <a href=#extending-bcp></a>: it is fully transparent to current RDF deployments, and it affects only application layers that do display the literal values for humans and it also works for parsers “out of the box. Because it is explicitly restricted to some specifications, it can (and should) be ignored by HTML, CSS, or other usage areas of [[bcp47]].
+                    A major advantage of this approach are similar to <a href=#extending-bcp></a>: it is fully transparent to current RDF deployments, and it affects only application layers that do display the literal values for humans and it also works for parsers “out of the box”. Because it is explicitly restricted to some specifications, it can (and should) be ignored by HTML, CSS, or other usage areas of [[bcp47]].
                 </p>
 
                 <p>

--- a/index.html
+++ b/index.html
@@ -535,7 +535,7 @@
                 </p>
             </section>
         </section>
-        <section>
+        <section id=hybrid>
             <h2>Hybrid solution</h2>
             <p>
                 This approach considers the “ideal” solution of <a href="#extending-lang-string">extending `langString`</a> (taking care of the core problem in RDF) but adding some feasibility considerations. The goal is to avoid the necessity to <a href="#full-family">update all RDF related specifications</a> at the same time. This could be achieved as follows.

--- a/index.html
+++ b/index.html
@@ -21,6 +21,12 @@
                 "w3cid": 7382,
                 "orcid": "0000-0003-0782-2704",
                 "companyURL": "https://www.w3.org",
+            },{ 
+                name:       "Pierre-Antoine Champin",
+                url:        "http://champin.net/",
+                company:    "LIRIS - Université de Lyon",
+                companyURL: "https://liris.cnrs.fr/",
+                w3cid:      42931,
             }],
             processVersion: 2018,
             includePermalinks: true,

--- a/index.html
+++ b/index.html
@@ -228,7 +228,7 @@
                 <section id="datatype-family">
                     <h2>Define a <em>family</em> of language datatypes</h2>
 
-                    <p>A (very large, albeit finite) family of datatypes can be defined using the following URL patterns: <code>https://www.w3.org/i18n#XX{_YY}</code>, where:</p>
+                    <p>A (very large, albeit finite) family of datatypes can be defined using the following URL pattern: <code>https://www.w3.org/i18n#XX{_YY}</code>, where:</p>
 
                     <ul>
                         <li>
@@ -254,6 +254,7 @@
                             The mapping means parsing the URL and mapping it to the corresponding tuple. 
                         </dd>
                     </dl>
+
                 </section>
             </section>
             <section>
@@ -447,7 +448,7 @@
                 }
             </pre>
 
-            <p>does, in fact, include the necessary information to deduce the rigth-to-left nature of the text by virtue of declaring the text to be in Hebrew, whereas in</p>
+            <p>does, in fact, include the necessary information to deduce the right-to-left nature of the text by virtue of declaring the text to be in Hebrew, whereas in</p>
 
             <pre class=nohighlight>
                 [] ex:example "<bdo dir="ltr">آذربايجانجا ديلي</bdo>"@az-Arab ; "Азәрбајҹан дили"@az-Cyrl .
@@ -543,15 +544,17 @@
 
             <ul>
                 <li>The core RDF 1.1 specification is updated, as described in <a href="#langString">the section above</a>.</li>
-                <li>New datatype(s) (as described <a href="datatype">above</a>) are defined, but with the following modifications:
+                <li>New datatype(s) (as described <a href="#datatype">above</a>) are defined, but with the following modifications:
                     <ul>
                         <li>
-                            these datatypes are defined to be deprecated soon, i.e., they are considered to be of a temporary usage only;
+                            These datatypes are defined to be deprecated eventually, i.e., they are considered to be of a temporary usage only;
                         </li>
                         <li>
-                            the value space for the datatype(s) consists of the renewed language string tuples as defined in the (renewed) RDF semantics document&nbsp;[[rdf11-mt]];
+                            The value space for the datatype(s) consists of the renewed language string tuples as defined in the (renewed) RDF semantics document&nbsp;[[rdf11-mt]];
                         </li>
-                        <li>the upcoming versions of N-Triple, N-Quads, Turtle, and TriG serializations are <em>not</em> modified; i.e., the only way to express the renewed <code>langString</code> is to use the new datatype(s).</li>
+                        <li>
+                            Current serializations (N-Triple, N-Quads, Turtle, TriG, etc.) would remain valid using the <code>"value"^^i18n:XX_YY</code> syntax. Upcoming versions MAY introduce new syntaxes (akin to what has been <a href="#base-serializations">described above</a>) to be mapped to the renewed language string tuples. However a base direction COULD still be expressed using the <code>"value"^^i18n:XX_YY</code> syntax, and that syntax would be specially parsed as the corresponding renewed language string, too. 
+                        </li>
                     </ul>
                 </li>
             </ul>
@@ -561,7 +564,7 @@
             </p>
 
             <p>
-                In view of their different usage pattersn, new versions of RDFa and JSON-LD may be updated, though, with the appropriate adaptations on the RDF Graphs they generate (e.g., if they generate N-Triples then the new datatypes should be used; if they are built on top of an RDF 1.2 compliant environment they would generate the proper value space entries).
+                In view of their different usage patterns, new versions of RDFa and JSON-LD may be updated, though, with the appropriate adaptations on the RDF Graphs they generate (e.g., if they generate N-Triples then the new datatypes should be used; if they are built on top of an RDF 1.2 compliant environment they would generate the proper value space entries).
             </p>
         </section>
         <section>
@@ -570,9 +573,8 @@
             <p>
                 The major advantage of this approach is that it combines the ideal solution of taking care of an RDF “bug” while ensuring a somewhat smoother deployment.
             </p>
-
             <p>
-                The disadvantage is that there has to be a very careful consideration when the datatypes are deprecated, rescinded, etc., i.e., it will need a careful monitoring of the RDF ecosystem evolution.
+                A disadvantage is that it creates a special case in several concrete syntaxes (e.g. Turtle), where the `i18:XX_YY` family of IRIs are used as "magic" terms, and end up being interpreted as a different IRI (namely `rdf:langString`). Another disadvantage is that there has to be a very careful consideration when the datatypes are deprecated, rescinded, etc., i.e., it will need a careful monitoring of the RDF ecosystem evolution.
             </p>
         </section>
     </section>

--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
                 company:    "LIRIS - Université de Lyon",
                 companyURL: "https://liris.cnrs.fr/",
                 w3cid:      42931,
+                orcid: "0000-0001-7046-4474",
             }],
             processVersion: 2018,
             includePermalinks: true,
@@ -588,7 +589,7 @@
     <section class=appendix>
         <h2>Acknowledgements</h2>
         <p>
-            This document is a synopsis of a series of discussions, email contributions, etc., of a number of people, including Manu Sporny, Pierre-Antoine Champin, Gregg Kellogg, David Longley, Rob Sanderson, Benjamin Young, Charles Neville, Richard Ishida, Addison Philips, Martin Dürst, and Mark Davis.
+            This document is a synopsis of a series of discussions, email contributions, etc., of a number of people, including Manu Sporny, Gregg Kellogg, David Longley, Rob Sanderson, Benjamin Young, Charles Neville, Richard Ishida, Addison Philips, Martin Dürst, and Mark Davis.
         </p>
     </section>
 

--- a/index.html
+++ b/index.html
@@ -105,7 +105,7 @@
         <section id=extending-lang-string>
             <h2>Extend <code>langString</code></h2>
 
-            <section>
+            <section id='langString'>
                 <h2>The core definition</h2>
                 <p>
                     The current definition for <code>langString</code> is in <a data-cite="!rdf11-concepts#section-Graph-Literal">section 3.3</a> of the RDF 1.1 document&nbsp;[[rdf11-concepts]]. It is based upon assigning a language tag, using&nbsp;[[bcp47]], to a string. It is somewhat of an odd case in the RDF&nbsp;1.1 model insofar as it has, in contrast to all other data types in RDF, an additional structure: the lexical space is a string <em>and</em> the additional (language) tag, and the value space of the datatype is also defined as a <em>tuple</em> consisting of the literal string and the language tag. This peculiarity means that <code>langString</code> literals have to be treated separately by all RDF implementations.
@@ -172,18 +172,17 @@
                 <h2>Pros and Cons</h2>
 
                 <p>
-                    Extending the <code>langString</code> can be considered as the “ideal” solution: it takes care of what could be considered (from an internationalization point of view) as a missing feature (some would call it a bug) in the original RDF specification. It also fits very well the current specification. Its effects on the RDF Semantics&nbsp;[[rdf11-mt]] is only editorial: the tuples for <code>langString</code> for <a data-cite="!rdf11-mt#literals-and-datatypes">literals</a>                    in general, and <a data-cite="!rdf11-mt#datatype-entailment">D-entailment</a> in particular, should simply include a new tag. Indeed, the RDF Semantics does not make use of the semantics of&nbsp;[[bcp47]] values, nor should it use the semantics of the base direction tag.
+                    Extending the <code>langString</code> can be considered as the “ideal” solution: it takes care of what could be considered (from an internationalization point of view) as a missing feature (some would call it a bug) in the original RDF specification. It also fits very well the current specification. Its effects on the RDF Semantics&nbsp;[[rdf11-mt]] is only editorial: the tuples for <code>langString</code> for <a data-cite="!rdf11-mt#literals-and-datatypes">literals</a> in general, and <a data-cite="!rdf11-mt#datatype-entailment">D-entailment</a> in particular, should simply include a new tag. Indeed, the RDF Semantics does not make use of the semantics of&nbsp;[[bcp47]] values, nor should it use the semantics of the base direction tag.
                 </p>
 
-                <p>
-                    The major problem is deployment. Because language tagged literals are treated separately in RDF, all implementations (Jena, RDFLib, Sesame, various triple stores, Turtle and RDF/XML parsers and serializers, etc.) MUST be updated. That may take a long time, and it may not be easy to convince the community to do so.
+                <p id="full-family">
+                    A major problem with the approach is that, because it touches the “core” or RDF, such a change would affect a large number of recommendations that all rely on that core: SPARQL, SHACL, RDFa, R2RML, etc. That means that if the core RDF specification is updated, _all other documents_ may have to be updated at the same time, which becomes a significant endeavor. Similarly, deployment is also a major problem: Because language tagged literals are treated separately in RDF, all implementations (Jena, RDFLib, Sesame, various triple stores, Turtle and RDF/XML parsers and serializers, etc.) MUST be updated. That may take a long time, and it may not be easy to convince the community to do so.
                 </p>
             </section>
         </section>
 
         <section id=datatype>
-            <h2>Define a <code>LocalizableString</code> datatype</h2>
-
+            <h2>Define new datatype(s)</h2>
             <p>
                 A new RDF <a data-cite="!rdf11-concepts#section-Datatypes">datatype</a> can be defined <em>on top of</em> the current RDF definition to cover the missing features.
             </p>
@@ -201,68 +200,118 @@
                     <li>Assign a unique URL to the new datatype.</li>
                 </ul>
 
-                <p>These requirements can defined, for this this case, as follows:</p>
+                <p>There may be different possibilities to define a new datatype (or datatypes)</p>
 
-                <dl>
-                    <dt>Lexical space</dt>
-                    <dd>
-                        Unicode [[UNICODE]] strings, which SHOULD be in Normal Form C&nbsp;[[nfc]], and which MUST follow the pattern <code>value@lang^dir</code>. <code>lang</code> is a&nbsp;[[bcp47]] language tag, <code>dir</code> MUST have the value of <code>ltr</code> or <code>rtl</code>, with the semantics as defined for the <a data-cite=!html/dom.html#the-dir-attribute><code>dir</code> attribute</a> in&nbsp;[[html]]. The presence of the <code>lang</code> pattern is REQUIRED; <code>^dir</code> is OPTIONAL.
-                    </dd>
-                    <dt>Value space</dt>
-                    <dd>
-                        Similar to the Lexical space, <em>except</em> that the <code>dir</code> value is REQUIRED and can also take the value of <code>auto</code> (with the semantics as defined for the <a data-cite=!html/dom.html#the-dir-attribute><code>dir</code> attribute</a>   in&nbsp;[[html]]).
-                    </dd>
-                    <dt>Lexical to value mapping</dt>
-                    <dd>
-                        If the lexical value is <code>value@lang^dir</code> the mapping is the identity mapping. If <code>^dir</code> is missing, then the corresponding value space entry is <code>value@lang^auto</code>.
-                    </dd>
-                    <dt>The URL uniquely defining the new datatype</dt>
-                    <dd>
-                        The obvious URL would be to put this into the RDF namespace, i.e., <code>http://www.w3.org/1999/02/22-rdf-syntax-ns#LocalizableString</code>.
-                    </dd>
-                </dl>
+                <section id="localizableStrings">
+                    <h2>Define a <code>LocalizableString</code> datatype</h2>
+                    <p>These requirements can defined, for this this case, as follows:</p>
+
+                    <dl>
+                        <dt>Lexical space</dt>
+                        <dd>
+                            Unicode [[UNICODE]] strings, which SHOULD be in Normal Form C&nbsp;[[nfc]], and which MUST follow the pattern <code>value@lang^dir</code>. <code>lang</code> is a&nbsp;[[bcp47]] language tag, <code>dir</code> MUST have the value of <code>ltr</code> or <code>rtl</code>, with the semantics as defined for the <a data-cite=!html/dom.html#the-dir-attribute><code>dir</code> attribute</a> in&nbsp;[[html]]. The presence of the <code>lang</code> pattern is REQUIRED; <code>^dir</code> is OPTIONAL.
+                        </dd>
+                        <dt>Value space</dt>
+                        <dd>
+                            Similar to the Lexical space, <em>except</em> that the <code>dir</code> value is REQUIRED and can also take the value of <code>auto</code> (with the semantics as defined for the <a data-cite=!html/dom.html#the-dir-attribute><code>dir</code> attribute</a>   in&nbsp;[[html]]).
+                        </dd>
+                        <dt>Lexical to value mapping</dt>
+                        <dd>
+                            If the lexical value is <code>value@lang^dir</code> the mapping is the identity mapping. If <code>^dir</code> is missing, then the corresponding value space entry is <code>value@lang^auto</code>.
+                        </dd>
+                        <dt>The URL uniquely defining the new datatype</dt>
+                        <dd>
+                            The obvious URL would be to put this into the RDF namespace, i.e., <code>http://www.w3.org/1999/02/22-rdf-syntax-ns#LocalizableString</code>.
+                        </dd>
+                    </dl>
+                </section>
+                <section id="datatype-family">
+                    <h2>Define a <em>family</em> of language datatypes</h2>
+
+                    <p>A (very large, albeit finite) family of datatypes can be defined using the following URL patterns: <code>https://www.w3.org/i18n#XX{_YY}</code>, where:</p>
+
+                    <ul>
+                        <li>
+                            <strong>XX</strong>: is a [[bcp47]] language tag
+                        </li>
+                        <li>
+                            <strong>YY</strong>: is <code>ltr</code> or <code>rtl</code>, with the semantics as defined for the <a data-cite=!html/dom.html#the-dir-attribute><code>dir</code> attribute</a> in&nbsp;[[html]]. This part may be missing.</dd>                    
+                        </li>
+                     </ul>
+
+                    For each of these datatypes there is an identical lexical and value space:
+                    <dl>
+                        <dt>Lexical space</dt>
+                        <dd>
+                            Unicode [[UNICODE]] strings, which SHOULD be in Normal Form C&nbsp;[[nfc]].
+                        </dd>
+                        <dt>Value space</dt>
+                        <dd>
+                            Tuples consisting of the string, the `XX` tag extracted from the URL, and a directional tag, which is either the value of the `YY` or, if missing, the value of `auto`.
+                        </dd>
+                        <dt>Lexical to value mapping</dt>
+                        <dd>
+                            The mapping means parsing the URL and mapping it to the corresponding tuple. 
+                        </dd>
+                    </dl>
+                </section>
             </section>
             <section>
                 <h2>Serializations</h2>
 
                 <p>Because this is a new datatype, strictly speaking there is no need for a new serialization; all concrete syntaxes have a way to express literals with a datatype. E.g., the literal would have the form of
 
-                    <pre class=nohighlight>
-						[] ex:example "<bdo dir="ltr">&#x05E4;&#x05E2;&#x05D9;&#x05DC;&#x05D5;&#x05EA; &#x05D4;&#x05D1;&#x05D9;&#x05E0;&#x05D0;&#x05D5;&#x05DD;, W3C</bdo>@he^rtl"^^rdf:LocalizableString .
-					</pre>
+                <pre class=nohighlight>
+                    [] ex:example "<bdo dir="ltr">&#x05E4;&#x05E2;&#x05D9;&#x05DC;&#x05D5;&#x05EA; &#x05D4;&#x05D1;&#x05D9;&#x05E0;&#x05D0;&#x05D5;&#x05DD;, W3C</bdo>@he^rtl"^^rdf:LocalizableString .
+                </pre>
 
-                    <p>in Turtle, and</p>
+                <p>or, respectively</p>
 
-                    <pre class=nohighlight>
-						"ex:example" : {
-						    "@value" : "<bdo dir="ltr">&#x05E4;&#x05E2;&#x05D9;&#x05DC;&#x05D5;&#x05EA; &#x05D4;&#x05D1;&#x05D9;&#x05E0;&#x05D0;&#x05D5;&#x05DD;, W3C</bdo>@he^rtl",
-						    "@datatype" : "rdf:LocalizableString"
-						}
-					</pre>
+                <pre class=nohighlight>
+                    [] ex:example "<bdo dir="ltr">&#x05E4;&#x05E2;&#x05D9;&#x05DC;&#x05D5;&#x05EA; &#x05D4;&#x05D1;&#x05D9;&#x05E0;&#x05D0;&#x05D5;&#x05DD;, W3C</bdo>"^^i18n:he_rtl .
+                </pre>
 
-                    <p>
-                        in JSON-LD 1.0.
-                    </p>
+                <p>in Turtle, and</p>
 
-                    <p>
-                        However, newer versions of the the serialization syntaxes MAY introduce the syntactic facilities to express this new datatype by adopting the <a href="#base-serializations">serialization formats</a> as defined for the <code>langString</code> extension case; these would be considered as syntactic sugar to generate these datatypes. E.g.,
-                    </p>
+                <pre class=nohighlight>
+                    "ex:example" : {
+                        "@value" : "<bdo dir="ltr">&#x05E4;&#x05E2;&#x05D9;&#x05DC;&#x05D5;&#x05EA; &#x05D4;&#x05D1;&#x05D9;&#x05E0;&#x05D0;&#x05D5;&#x05DD;, W3C</bdo>@he^rtl",
+                        "@datatype" : "rdf:LocalizableString"
+                    }
+                </pre>
 
-                    <pre class=nohighlight>
-						"ex:example" : {
-						    "@value" : "<bdo dir="ltr">&#x05E4;&#x05E2;&#x05D9;&#x05DC;&#x05D5;&#x05EA; &#x05D4;&#x05D1;&#x05D9;&#x05E0;&#x05D0;&#x05D5;&#x05DD;, W3C</bdo>"
-						    "@language" : "he",
-						    "@direction" : "rtl"
-						}
-					</pre>
+                <p>or, respectively</p>
 
-                    <p>
-						could be considered as valid, generating a <code>LocalizableString</code> when mapped upon RDF. An advantage of introducing such a shorthand in JSON is that vanilla JSON may adopt the same pattern which can be used in general (see also the definition of <a data-cite="string-meta#Localizable-String-Dictionary"><code>Localizable</code></a>.)
-					</p>
+                <pre class=nohighlight>
+                    "ex:example" : {
+                        "@value" : "<bdo dir="ltr">&#x05E4;&#x05E2;&#x05D9;&#x05DC;&#x05D5;&#x05EA; &#x05D4;&#x05D1;&#x05D9;&#x05E0;&#x05D0;&#x05D5;&#x05DD;, W3C</bdo>",
+                        "@datatype" : "i18n:he_rtl"
+                    }
+                </pre>
 
-                    <p>
-						(Care should be taken of the fact that adopting such extra syntactic facilities means that the same localizable string could be expressed in two different ways. While this may not create too much problems in most cases, it may require some extra considerations if and when a canonical RDF format is defined.)
-					</p>
+                <p>
+                    in JSON-LD 1.0. 
+                </p>
+
+                <p>
+                    However, newer versions of the the serialization syntaxes MAY introduce the syntactic facilities to express this new datatype by adopting the <a href="#base-serializations">serialization formats</a> as defined for the <code>langString</code> extension case; these would be considered as syntactic sugar to generate these datatypes. E.g.,
+                </p>
+
+                <pre class=nohighlight>
+                    "ex:example" : {
+                        "@value" : "<bdo dir="ltr">&#x05E4;&#x05E2;&#x05D9;&#x05DC;&#x05D5;&#x05EA; &#x05D4;&#x05D1;&#x05D9;&#x05E0;&#x05D0;&#x05D5;&#x05DD;, W3C</bdo>"
+                        "@language" : "he",
+                        "@direction" : "rtl"
+                    }
+                </pre>
+
+                <p>
+                    could be considered as valid, generating a <code>LocalizableString</code>, or <code>i18n:*</code>, respectively, when mapped upon RDF. An advantage of introducing such a shorthand in JSON is that vanilla JSON may adopt the same pattern which can be used in general (see also the definition of <a data-cite="string-meta#Localizable-String-Dictionary"><code>Localizable</code></a>.)
+                </p>
+
+                <p>
+                    (Care should be taken of the fact that adopting such extra syntactic facilities means that the same localizable string could be expressed in two different ways. While this may not create too much problems in most cases, it may require some extra considerations if and when a canonical RDF format is defined.)
+                </p>
             </section>
             <section>
                 <h2>Pros and Cons</h2>
@@ -305,11 +354,11 @@
                 <p>in Turtle, and</p>
 
                 <pre class=nohighlight>
-						"ex:example" : {
-						    "@value" : "<bdo dir="ltr">&#x05E4;&#x05E2;&#x05D9;&#x05DC;&#x05D5;&#x05EA; &#x05D4;&#x05D1;&#x05D9;&#x05E0;&#x05D0;&#x05D5;&#x05DD;, W3C</bdo>",
-						    "@language" : "he-d-rtl"
-						}
-					</pre>
+                    "ex:example" : {
+                        "@value" : "<bdo dir="ltr">&#x05E4;&#x05E2;&#x05D9;&#x05DC;&#x05D5;&#x05EA; &#x05D4;&#x05D1;&#x05D9;&#x05E0;&#x05D0;&#x05D5;&#x05DD;, W3C</bdo>",
+                        "@language" : "he-d-rtl"
+                    }
+                </pre>
 
                 <p>in JSON-LD.</p>
             </section>
@@ -485,6 +534,46 @@
                     Also, just as for <a href="#extending-bcp"></a> and <a href="#private-tag"></a>, the interplay between current data deployment and the assignment of such extra formatting characters may not be obvious. Although <a href="https://github.com/w3c/rdf-dir-literal/issues/7#issuecomment-497337353">the issue comment</a> and the <a href="https://github.com/w3c/rdf-dir-literal/wiki/Draft-ideas-related-to-string-metadata-storage-options">separate Wiki</a> page outline the problems for the case when the language tags are used, the same considerations apply to this approach as well.
                 </p>
             </section>
+        </section>
+        <section>
+            <h2>Hybrid solution</h2>
+            <p>
+                This approach considers the “ideal” solution of <a href="#extending-lang-string">extending `langString`</a> (taking care of the core problem in RDF) but adding some feasibility considerations. The goal is to avoid the necessity to <a href="#full-family">update all RDF related specifications</a> at the same time. This could be achieved as follows.
+            </p>
+
+            <ul>
+                <li>The core RDF 1.1 specification is updated, as described in <a href="#langString">the section above</a>.</li>
+                <li>New datatype(s) (as described <a href="datatype">above</a>) are defined, but with the following modifications:
+                    <ul>
+                        <li>
+                            these datatypes are defined to be deprecated soon, i.e., they are considered to be of a temporary usage only;
+                        </li>
+                        <li>
+                            the value space for the datatype(s) consists of the renewed language string tuples as defined in the (renewed) RDF semantics document&nbsp;[[rdf11-mt]];
+                        </li>
+                        <li>the upcoming versions of N-Triple, N-Quads, Turtle, and TriG serializations are <em>not</em> modified; i.e., the only way to express the renewed <code>langString</code> is to use the new datatype(s).</li>
+                    </ul>
+                </li>
+            </ul>
+
+            <p>
+                What this hybrid approach brings is that, in the first round, it is enough to update RDF 1.1 (as described in the <a href="#langString">separate section</a>) but the other specifications, as well as their deployments, are not under the pressure to be updated right away. Graphs using the new datatypes can be defined using the traditional syntaxes. At a later point, when the usage becomes widespread, the datatypes might be rescinded, alongside the updates SPARQL, SHACL, etc., specifications being updated to a new <code>langString</code> use.
+            </p>
+
+            <p>
+                In view of their different usage pattersn, new versions of RDFa and JSON-LD may be updated, though, with the appropriate adaptations on the RDF Graphs they generate (e.g., if they generate N-Triples then the new datatypes should be used; if they are built on top of an RDF 1.2 compliant environment they would generate the proper value space entries).
+            </p>
+        </section>
+        <section>
+            <h2>Pros and Cons</h2>
+
+            <p>
+                The major advantage of this approach is that it combines the ideal solution of taking care of an RDF “bug” while ensuring a somewhat smoother deployment.
+            </p>
+
+            <p>
+                The disadvantage is that there has to be a very careful consideration when the datatypes are deprecated, rescinded, etc., i.e., it will need a careful monitoring of the RDF ecosystem evolution.
+            </p>
         </section>
     </section>
 


### PR DESCRIPTION
I am mindful of the fact that the proposal must be published for a larger community soon (AC, plus other interested parties) to collect reactions. To make that comment period more efficient, I have:

- incorporated the alternative datatype of @pchampin into the main document
- I have also added a new approach to the document that I nicknamed 'hybrid' which outlines the approach we have been discussing in the separate issue https://github.com/w3c/rdf-dir-literal/issues/13
- I have prepared a version of the charter draft that offers a choice between the two versions: the pure `langString` update and the hybrid solution (I hope the way I did it in the text is understandable)

The readable version of the charter is: https://raw.githack.com/w3c/rdf-dir-literal/hybrid-solution/draft-charter.html

(The pr-preview works only on the core document...)

Cc: @pchampin @gkellogg @swickr @aphillips @chaals @dlongley @r12a @msporny (change proposals welcome!)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-dir-literal/pull/14.html" title="Last updated on Jun 13, 2019, 6:13 PM UTC (ee97bf0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-dir-literal/14/89a8b8d...ee97bf0.html" title="Last updated on Jun 13, 2019, 6:13 PM UTC (ee97bf0)">Diff</a>