### PR TITLE
Added compound literals

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,8 @@
                 repoURL: "https://github.com/w3c/rdf-dir-literal/",
                 branch: "master"
             },
-            localBiblio: biblio
+            localBiblio: biblio,
+            maxTocLevel: 4
         };
     </script>
     <style>
@@ -363,69 +364,53 @@
             </section>
 
             <section id=hybrid>
-                    <h2>Hybrid solution</h2>
-                    <p>
-                        This approach considers the “ideal” solution of <a href="#extending-lang-string">extending `langString`</a> (taking care of the core problem in RDF) but adding some feasibility considerations. The goal is to avoid the necessity to <a href="#full-family">update all RDF related specifications</a> at the same time. This could be achieved as follows.
-                    </p>
+                <h2>Hybrid solution</h2>
+                <p>
+                    This approach considers the “ideal” solution of <a href="#extending-lang-string">extending `langString`</a> (taking care of the core problem in RDF) but adding some feasibility considerations. The goal is to avoid the necessity to <a href="#full-family">update all RDF related specifications</a> at the same time. This could be achieved as follows.
+                </p>
 
-                    <p class=note>
-                        It is worth noting that, in all solutions proposed above, the value space of the updated/new datatype is identical: triples consisting of the string, the language tag, and a base direction tag, where at most one of the tags may be <code>undefined</code>.
-                    </p>
+                <p class=note>
+                    It is worth noting that, in all solutions proposed above, the value space of the updated/new datatype is identical: triples consisting of the string, the language tag, and a base direction tag, where at most one of the tags may be <code>undefined</code>.
+                </p>
 
-                    <ul>
-                        <li>One of the new datatypes (or family thereof), as described <a href="#datatype">above</a>, is adopted, with the explicit provision that it is to be deprecated eventually. I.e., it is considered to be of a temporary usage only.</li>
-                        <li>The core RDF 1.1 specification is updated, as described in <a href="#langString">the section above</a>.
-                            <ul>
-                                <li>
-                                    The serializations of the new datatype(s) (in N-Triple, N-Quads, Turtle, TriG, etc.) would remain valid (e.g., <code>"value@XX^YY"^^rdf:LocalizableString</code>, or <code>"value"^^i18n:XX_YY</code>, respectively). However, they would be specially parsed and mapped to the renewed <code>rdf:langString</code> datatype.</li>
-                                <li>
-                                    New syntaxes (akin to what has been <a href="#base-serializations">described above</a>) MAY also be introduced. However, to ensure interoperability with older RDF implementations, serializers MAY keep using the special syntax described above. 
-                                </li>
-                            </ul>
-                        </li>
-                    </ul>
+                <ul>
+                    <li>One of the new datatypes (or family thereof), as described <a href="#datatype">above</a>, is adopted, with the explicit provision that it is to be deprecated eventually. I.e., it is considered to be of a temporary usage only.</li>
+                    <li>The core RDF 1.1 specification is updated, as described in <a href="#langString">the section above</a>.
+                        <ul>
+                            <li>
+                                The serializations of the new datatype(s) (in N-Triple, N-Quads, Turtle, TriG, etc.) would remain valid (e.g., <code>"value@XX^YY"^^rdf:LocalizableString</code>, or <code>"value"^^i18n:XX_YY</code>, respectively). However, they would be specially parsed and mapped to the renewed <code>rdf:langString</code> datatype.</li>
+                            <li>
+                                New syntaxes (akin to what has been <a href="#base-serializations">described above</a>) MAY also be introduced. However, to ensure interoperability with older RDF implementations, serializers MAY keep using the special syntax described above.
+                            </li>
+                        </ul>
+                    </li>
+                </ul>
+
+                <p>
+                    What this hybrid approach brings is that, as the first step, it is enough to update RDF 1.1 (as described in the <a href="#langString">separate section</a>). The other specifications, as well as their deployments, are not under the pressure to be updated right away. Graphs using the new datatypes can be defined using the traditional syntaxes. At a later point, when the usage becomes widespread, the datatypes might be rescinded, alongside the updates of SPARQL, SHACL, etc., incorporating the new <code>langString</code>.
+                </p>
+
+                <p>
+                    In view of their different usage patterns, new versions of RDFa and JSON-LD may be updated, though, with the appropriate adaptations on the RDF Graphs they generate (e.g., if they generate N-Triples then the new temporary datatypes should be used; if they are built on top of an RDF 1.2 compliant environment they would generate the proper value space entries).
+                </p>
+                <section>
+                    <h2>Pros and Cons</h2>
         
                     <p>
-                        What this hybrid approach brings is that, as the first step, it is enough to update RDF 1.1 (as described in the <a href="#langString">separate section</a>). The other specifications, as well as their deployments, are not under the pressure to be updated right away. Graphs using the new datatypes can be defined using the traditional syntaxes. At a later point, when the usage becomes widespread, the datatypes might be rescinded, alongside the updates of SPARQL, SHACL, etc., incorporating the new <code>langString</code>.
+                        The major advantage of this approach is that it combines the ideal solution of taking care of an RDF “bug” while ensuring a somewhat smoother deployment.
                     </p>
-        
                     <p>
-                        In view of their different usage patterns, new versions of RDFa and JSON-LD may be updated, though, with the appropriate adaptations on the RDF Graphs they generate (e.g., if they generate N-Triples then the new temporary datatypes should be used; if they are built on top of an RDF 1.2 compliant environment they would generate the proper value space entries).
+                        A disadvantage is that it creates a special case in several concrete syntaxes (e.g. Turtle), where the <code>rdf:LocalizableString</code> or <code>i18:XX_YY</code> family of IRIs are used as "magic" terms, and end up being interpreted as a different IRI (namely <code>rdf:langString</code>). Another disadvantage is that there has to be a very careful consideration when the datatypes are deprecated, rescinded, etc., i.e., it will need a careful monitoring of the RDF ecosystem evolution.
                     </p>
-                    <section>
-                        <h2>Pros and Cons</h2>
-            
-                        <p>
-                            The major advantage of this approach is that it combines the ideal solution of taking care of an RDF “bug” while ensuring a somewhat smoother deployment.
-                        </p>
-                        <p>
-                            A disadvantage is that it creates a special case in several concrete syntaxes (e.g. Turtle), where the <code>rdf:LocalizableString</code> or <code>i18:XX_YY</code> family of IRIs are used as "magic" terms, and end up being interpreted as a different IRI (namely <code>rdf:langString</code>). Another disadvantage is that there has to be a very careful consideration when the datatypes are deprecated, rescinded, etc., i.e., it will need a careful monitoring of the RDF ecosystem evolution.
-                        </p>
-                    </section>
                 </section>
+            </section>
         
 
-
-            <section>
-                <h2>General comments: Pros and Cons</h2>
+            <section id="compound-literal">
+                <h2>Compound literal</h2>
                 <p>
-                    The major advantage of these solutions is that it keeps the changes “confined” to the realm of RDF, with no danger of interference with other technologies (in contrast to the <a href="#bcp47_based"></a> approach below).
+                    This solution is inspired by a separate discussion of the RDF community on <a href='https://github.com/w3c/EasierRDF/issues/22'>“Language Tagged Strings”</a> (that issue summarizes a large number of mails related to this topic that have been accumulated over the years). The essence of the discussion is to separate the “string”, as a simple data, from <em>all</em> the various characterizations that may be added to it. Language is one of those, but one can refer to, say, pronunciation issues, translation-related terms (like in [[its]]) and, of course direction. <em>We should not aim at solving all the issues raised in that discussion</em>, but we can get inspired and provide a basis for the community to carry on further, if it wishes.
                 </p>
-
-                <p>
-                    The major disadvantage of these solutions is that touches the “core” of the RDF family of specifications, that comprises, by now, a rather large number of technologies (SPARQL, SHACL, conversion standards like R2RML or CSVW, etc), and this means that, eventually, all these standards must be refined in some way or other. Using a <a href=#datatype>datatype</a> and, mainly, the <a href="hybrid">“hybrid”</a> approach mitigates the problem somewhat but, even in that case, applications SHOULD, eventually, be adapted to these new datatypes, which necessitates, per W3C process, setting up dedicated Working Groups. 
-                </p>
-            </section>
-        </section>
-
-        <section id="vocabulary_based">
-            <h2>Compound literal based solution</h2>
-            <p>
-                This solution is inspired by a separate discussion of the RDF community on <a href='https://github.com/w3c/EasierRDF/issues/22'>“Language Tagged Strings”</a> (that issue summarizes a large number of mails related to this issue that have been accumulated over the years). The essence of the discussion is to separate the “string”, as a simple data, from <em>all</em> the various characterizations that may be added to a string. Language is one of those, but one can refer to, say, pronunciation issues, translation-related terms (like in [[its]]) and, of course direction. _We should not aim at solving all the issues raised in that discussion_, but we can get inspired and provide a basis for the community to carry on further, if it wishes. 
-            </p>
-
-            <section>
-                <h2><code>CompoundLiteral</code> (RDF) class</h2>
 
                 <section>
                     <h2>Core definition</h2>
@@ -518,13 +503,22 @@
                     <p>
                         The obvious disadvantage is that it duplicates a mechanism for expressing strings with a language tag <em>only</em>: one can use the core <code>langString</code> datatype <em>or</em> the compound literals. The relationship between the two forms should be specified.
                     </p>
-
-                    <p>
-                        (It would be possible to make a “mix” whereby, instead of using <code>rdf:language</code>, one would use a <code>rdf:langString</code> as an object for <code>rdf:value</code>.)
-                    </p>
                 </section>
             </section>
+
+
+            <section>
+                <h2>General comments: Pros and Cons</h2>
+                <p>
+                    The major advantage of these solutions is that they keep the changes “confined” to the realm of RDF, with no danger of interference with other technologies (in contrast to the <a href="#bcp47_based"></a> approach below).
+                </p>
+
+                <p>
+                    The major disadvantage of these solutions is that they touch the “core” of the RDF family of specifications, that comprises, by now, a rather large number of technologies (SPARQL, SHACL, conversion standards like R2RML or CSVW, etc), and this means that, eventually, all these standards must be refined in one way or another. This is particularly true for <a href="#extending-lang-string"></a>, which directly extends the RDF model. The other solutions in this section, in particular the <a href="#hybrid">hybrid approach</a>, mitigate the problem somewhat. But even in that case, applications SHOULD, eventually, be adapted to the new structure of literals, which necessitates, per W3C process, setting up dedicated Working Groups.
+                </p>
+            </section>
         </section>
+
 
 
         <section id="bcp47_based">

--- a/index.html
+++ b/index.html
@@ -514,7 +514,7 @@
                 </p>
 
                 <p>
-                    The major disadvantage of these solutions is that they touch the “core” of the RDF family of specifications, that comprises, by now, a rather large number of technologies (SPARQL, SHACL, conversion standards like R2RML or CSVW, etc), and this means that, eventually, all these standards must be refined in one way or another. This is particularly true for <a href="#extending-lang-string"></a>, which directly extends the RDF model. The other solutions in this section, in particular the <a href="#hybrid">hybrid approach</a>, mitigate the problem somewhat. But even in that case, applications SHOULD, eventually, be adapted to the new structure of literals, which necessitates, per W3C process, setting up dedicated Working Groups.
+                    The major disadvantage of these solutions is that they touch the “core” of the RDF family of specifications, that comprises, by now, a rather large number of technologies (SPARQL, SHACL, conversion standards like R2RML or CSVW, etc), and this means that, eventually, all these standards must be refined in one way or another. This is particularly true for <a href="#extending-lang-string"></a>, which directly extends the RDF model. The other solutions in this section, in particular the <a href="#hybrid">hybrid approach</a>, mitigate the problem somewhat. But even in that case, applications SHOULD, eventually, be adapted to the new structure of literals, which may require, per W3C process, setting up dedicated Working Groups.
                 </p>
             </section>
         </section>

--- a/index.html
+++ b/index.html
@@ -447,14 +447,14 @@
                         _:a rdf:direction "rtl" .
                     </pre>
 
-                    <p>The (blank) node <code>_:a</code> stands for the literal, whose language is Hebrew, and whose direction is right-to-left. It usage would be (using the turtle syntax to make it a bit simpler):</p>
+                    <p>The (blank) node <code>_:a</code> stands for the literal, whose language is Hebrew, and whose direction is right-to-left.</p>
 
                     <p class=note>The <code>rdf:</code> namespace has been used in the definition for the sake of simplicity; it is a separate decision whether that, or another namespace should be used. </p>
 
                     <section id=rdf-like>
                         <h2>A more “RDF-like” variant</h2>
 
-                        <p>From strict RDF point of view, the definition is sloppy; it attaches an extra semantics to the values of literals instead of making using URLs for clear terms. A cleaner definition may be to define the following terms:</p>
+                        <p>From strict RDF point of view, the definition above is sloppy; it attaches an extra semantics to the values of literals instead of using URLs for identifying distinct notions such as languages and directions. A cleaner definition may be to define the following terms:</p>
 
                         <ul>
                             <li><code>rdf:CompoundLiteral</code>: is a class representing a compound literal.</li>
@@ -512,11 +512,11 @@
                 <section>
                     <h2>Pros and Cons</h2>
                     <p>
-                        The major advantage of this approach is that it is fully transparent to current RDF deployments, and affects only application layers that do display the literal values for humans. They also work for parsers “out of the box”. As an extra bonus (as mentioned <a href='https://github.com/w3c/EasierRDF/issues/22'>“Language Tagged Strings”</a> discussion) it may actually be easier to search such compound literals via, say, SPARQL then using the current RDF approach.
+                        The major advantage of this approach is that it is fully transparent to current RDF deployments, and affects only application layers that do display the literal values for humans. It also work for parsers “out of the box”. As an extra bonus (as mentioned <a href='https://github.com/w3c/EasierRDF/issues/22'>“Language Tagged Strings”</a> discussion) it may actually be easier to query such compound literals via, say, SPARQL than using the current RDF approach.
                     </p>
 
                     <p>
-                        The obvious disadvantage is that it duplicates a mechanism for expressing string with the language tag <em>only</em>: one can use the core <code>langString</code> datatype <em>or</em> the compound literals. The relationship between the two forms should be specified.
+                        The obvious disadvantage is that it duplicates a mechanism for expressing strings with a language tag <em>only</em>: one can use the core <code>langString</code> datatype <em>or</em> the compound literals. The relationship between the two forms should be specified.
                     </p>
 
                     <p>

--- a/index.html
+++ b/index.html
@@ -168,7 +168,7 @@
                         <h2>Turtle/SPARQL</h2>
                         <p>Turtle has a special syntax for language tagged literals which could be extended, e.g.,:</p>
     
-                        <pre class="nohighlight">
+                        <pre class="nohighlight" id="langstring-example">
                             [] ex:example "<bdo dir="ltr">&#x05E4;&#x05E2;&#x05D9;&#x05DC;&#x05D5;&#x05EA; &#x05D4;&#x05D1;&#x05D9;&#x05E0;&#x05D0;&#x05D5;&#x05DD;, W3C</bdo>"@he^rtl ;
                                ex:isbn "978-2-290-16543-0"@^ltr .
                         </pre>
@@ -413,8 +413,116 @@
                 </p>
 
                 <p>
-                    The major disadvantage of this solution is that touches the “core” of the RDF family of specifications, that comprises, by now, a rather large number of technologies (SPARQL, SHACL, conversion standards like R2RML or CSVW, etc), and this means that, eventually, all these standards must be refined in some way or other. Using a <a href=#datatype>datatype</a> and, mainly, the <a href="hybrid">“hybrid”</a> approach mitigates the problem somewhat but, even in that case, applications SHOULD, eventually, be adapted to these new datatypes, which necessitates, per W3C process, setting up dedicated Working Groups. 
+                    The major disadvantage of these solutions is that touches the “core” of the RDF family of specifications, that comprises, by now, a rather large number of technologies (SPARQL, SHACL, conversion standards like R2RML or CSVW, etc), and this means that, eventually, all these standards must be refined in some way or other. Using a <a href=#datatype>datatype</a> and, mainly, the <a href="hybrid">“hybrid”</a> approach mitigates the problem somewhat but, even in that case, applications SHOULD, eventually, be adapted to these new datatypes, which necessitates, per W3C process, setting up dedicated Working Groups. 
                 </p>
+            </section>
+        </section>
+
+        <section id="vocabulary_based">
+            <h2>Compound literal based solution</h2>
+            <p>
+                This solution is inspired by a separate discussion of the RDF community on <a href='https://github.com/w3c/EasierRDF/issues/22'>“Language Tagged Strings”</a> (that issue summarizes a large number of mails related to this issue that have been accumulated over the years). The essence of the discussion is to separate the “string”, as a simple data, from <em>all</em> the various characterizations that may be added to a string. Language is one of those, but one can refer to, say, pronunciation issues, translation-related terms (like in [[its]]) and, of course direction. _We should not aim at solving all the issues raised in that discussion_, but we can get inspired and provide a basis for the community to carry on further, if it wishes. 
+            </p>
+
+            <section>
+                <h2><code>CompoundLiteral</code> (RDF) class</h2>
+
+                <section>
+                    <h2>Core definition</h2>
+
+                    <p>The following terms are defined in RDF:</p>
+
+                    <ul>
+                        <li><code>rdf:CompoundLiteral</code>: is a class representing a compound literal.</li>
+                        <li><code>rdf:language</code>: an RDF <em>property</em>. The range of the property is an <code>rdfs:Literal</code>, whose value must be a well-formed [[bcp47]] tag. The domain of the property is <code>rdf:CompoundLiteral</code>.</li>
+                        <li><code>rdf:direction</code>: an RDF <em>property</em>. The range of the property must be an <code>rdfs:Literal</code>, whose value must be either <code>"ltr"</code> or <code>"rtl"</code>. The domain of the property is <code>rdf:CompoundLiteral</code>.</li>
+                    </ul>
+    
+                    <p>Semantically, the following triples represent a compound literal, whose language and base direction are specified:</p>
+    
+                    <pre class=nohighlight>
+                        _:a rdf:type rdf:CompoundLiteral .
+                        _:a rdf:value "<bdo dir="ltr">&#x05E4;&#x05E2;&#x05D9;&#x05DC;&#x05D5;&#x05EA; &#x05D4;&#x05D1;&#x05D9;&#x05E0;&#x05D0;&#x05D5;&#x05DD;, W3C</bdo>" .
+                        _:a rdf:language "he" . 
+                        _:a rdf:direction "rtl" .
+                    </pre>
+
+                    <p>The (blank) node <code>_:a</code> stands for the literal, whose language is Hebrew, and whose direction is right-to-left. It usage would be (using the turtle syntax to make it a bit simpler):</p>
+
+                    <p class=note>The <code>rdf:</code> namespace has been used in the definition for the sake of simplicity; it is a separate decision whether that, or another namespace should be used. </p>
+
+                    <section id=rdf-like>
+                        <h2>A more “RDF-like” variant</h2>
+
+                        <p>From strict RDF point of view, the definition is sloppy; it attaches an extra semantics to the values of literals instead of making using URLs for clear terms. A cleaner definition may be to define the following terms:</p>
+
+                        <ul>
+                            <li><code>rdf:CompoundLiteral</code>: is a class representing a compound literal.</li>
+                            <li>the set of individuals of the form <code>https://www.w3.org/i18n/lang#XX</code>, where <code>XX</code> is a well-formed [[bcp47]] tag (the class of language tags)</li>
+                            <li>the set of the two individuals of the form <code>https://www.w3.org/i18n/dir#ltr</code> and <code>https://www.w3.org/i18n/dir#rtl</code> (the class of direction tags)</li>
+                            <li><code>rdf:language</code>: an RDF <em>property</em>. The range of the property is the class of language tag URL, the domain is <code>rdf:CompoundLiteral</code>
+                            <li><code>rdf:direction</code>: an RDF <em>property</em>. The range of the property is the class of direction tag URL, the domain is <code>rdf:CompoundLiteral</code>
+                        </ul>
+
+                        <p>Using the <code>i18n:</code> namespace the example representation would look slightly different:</p>
+
+                        <pre class=nohighlight>
+                            _:a rdf:type rdf:CompoundLiteral .
+                            _:a rdf:value "<bdo dir="ltr">&#x05E4;&#x05E2;&#x05D9;&#x05DC;&#x05D5;&#x05EA; &#x05D4;&#x05D1;&#x05D9;&#x05E0;&#x05D0;&#x05D5;&#x05DD;, W3C</bdo>" .
+                            _:a rdf:language i18n:lang#he . 
+                            _:a rdf:direction i18n:dir#rtl .
+                        </pre>
+
+                    </section>
+                </section>
+                
+                <section>
+                    <h2>Serializations</h2>
+
+                    <p>(The serialization of the <a href="#rdf-like">RDF like variant</a> is left as an exercise for the reader.) </p>
+
+                    <section>
+                        <h2>Turtle</h2>
+                        <pre class=nohighlight>
+                                [] ex:example [
+                                    rdf:value "<bdo dir="ltr">&#x05E4;&#x05E2;&#x05D9;&#x05DC;&#x05D5;&#x05EA; &#x05D4;&#x05D1;&#x05D9;&#x05E0;&#x05D0;&#x05D5;&#x05DD;, W3C</bdo>" ;
+                                    rdf:language "he" ; 
+                                    rdf:direction "rtl" ;
+                                ] .
+                        </pre>
+                                    
+                        <p>Note that, compared to <a href="#langstring-example">previous examples</a> the text does not appear directly as the object of a triple, but is encapsulated in a separate (blank) node that “represents” the text with all attributes attached.</p>
+                    </section>
+
+                    <section>
+                        <h2>JSON-LD</h2>
+                        <p>Interestingly, due to the specificities of the JSON-LD syntax, the serialization of compound literals is extremely straightforward. Indeed, a syntax of the form:</p>
+
+                        <pre class=nohighlight>
+                            "ex:example" : {
+                                "@value" : "<bdo dir="ltr">&#x05E4;&#x05E2;&#x05D9;&#x05DC;&#x05D5;&#x05EA; &#x05D4;&#x05D1;&#x05D9;&#x05E0;&#x05D0;&#x05D5;&#x05DD;, W3C</bdo>"
+                                "@language" : "he",
+                                "@direction" : "rtl"
+                            }
+                        </pre>
+            
+                        <p>may be mapped onto compound literals directly.</p>
+                    </section>
+                </section>
+                <section>
+                    <h2>Pros and Cons</h2>
+                    <p>
+                        The major advantage of this approach is that it is fully transparent to current RDF deployments, and affects only application layers that do display the literal values for humans. They also work for parsers “out of the box”. As an extra bonus (as mentioned <a href='https://github.com/w3c/EasierRDF/issues/22'>“Language Tagged Strings”</a> discussion) it may actually be easier to search such compound literals via, say, SPARQL then using the current RDF approach.
+                    </p>
+
+                    <p>
+                        The obvious disadvantage is that it duplicates a mechanism for expressing string with the language tag <em>only</em>: one can use the core <code>langString</code> datatype <em>or</em> the compound literals. The relationship between the two forms should be specified.
+                    </p>
+
+                    <p>
+                        (It would be possible to make a “mix” whereby, instead of using <code>rdf:language</code>, one would use a <code>rdf:langString</code> as an object for <code>rdf:value</code>.)
+                    </p>
+                </section>
             </section>
         </section>
 
@@ -620,7 +728,7 @@
     <section class=appendix>
         <h2>Acknowledgements</h2>
         <p>
-            This document is a synopsis of a series of discussions, email contributions, etc., of a number of people, including Manu Sporny, Gregg Kellogg, David Longley, Rob Sanderson, Benjamin Young, Charles Neville, Richard Ishida, Addison Philips, Martin Dürst, and Mark Davis.
+            This document is a synopsis of a series of discussions, email contributions, etc., of a number of people, including Manu Sporny, Gregg Kellogg, David Longley, Rob Sanderson, Benjamin Young, Charles Neville, Richard Ishida, Addison Philips, Martin Dürst, Andy Seaborne, and Mark Davis.
         </p>
     </section>
 


### PR DESCRIPTION
I picked up #22 and added to the document as yet another, possible solution; thanks to @afs  

@afs can you look at this to see if it makes sense?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-dir-literal/pull/23.html" title="Last updated on Aug 29, 2019, 1:16 PM UTC (975f6ae)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-dir-literal/23/8447257...975f6ae.html" title="Last updated on Aug 29, 2019, 1:16 PM UTC (975f6ae)">Diff</a>